### PR TITLE
Replace url() helper with static login url

### DIFF
--- a/config/littlegatekeeper.php
+++ b/config/littlegatekeeper.php
@@ -9,5 +9,5 @@ return [
     'sessionKey' => 'littlegatekeeper.loggedin',
 
     // The route to which the middleware redirects if a user isn't authenticated
-    'authRoute' => url('login'),
+    'authRoute' => 'auth/login',
 ];


### PR DESCRIPTION
Using functions in the config files won't make it possible to cache your config in Laravel, therefore, the `authRoute` value in the `config/littlegatekeeper.php` file should be renamed statically.

Also, this follows Laravel, as they recommend specifying the home URL manually in the `RouteServiceProvider` as of [https://laravel.com/docs/7.x/authentication#included-authenticating](https://laravel.com/docs/7.x/authentication#included-authenticating).