### PR TITLE
Fix syntax error

### DIFF
--- a/src/LittleGateKeeperServiceProvider.php
+++ b/src/LittleGateKeeperServiceProvider.php
@@ -38,7 +38,7 @@ class LittleGateKeeperServiceProvider extends ServiceProvider
                    $app->config->get('littlegatekeeper.password'),
                    $app->config->get('littlegatekeeper.sessionKey'),
                    $app->make(Session::class)
-                )
+                );
              });
 
         $this->app->alias(Authenticator::class, 'littlegatekeeper');


### PR DESCRIPTION
Was getting this error:

```
PHP Parse error:  syntax error, unexpected '}', expecting ';' in LittleGateKeeperServiceProvider.php on line 42

Parse error: syntax error, unexpected '}', expecting ';' in LittleGateKeeperServiceProvider.php on line 42
```