### PR TITLE
Change instance to bind

### DIFF
--- a/src/LittleGateKeeperServiceProvider.php
+++ b/src/LittleGateKeeperServiceProvider.php
@@ -30,16 +30,16 @@ class LittleGateKeeperServiceProvider extends ServiceProvider
            __DIR__.'/../config/littlegatekeeper.php', 'littlegatekeeper'
         );
 
-        $this->app->instance(
+        $this->app->bind(
             Authenticator::class,
-             function ($app) {
+            function ($app) {
                 return new Authenticator(
                    $app->config->get('littlegatekeeper.username'),
                    $app->config->get('littlegatekeeper.password'),
                    $app->config->get('littlegatekeeper.sessionKey'),
                    $app->make(Session::class)
                 );
-             });
+            }, true);
 
         $this->app->alias(Authenticator::class, 'littlegatekeeper');
     }


### PR DESCRIPTION
As pointed out by MalikinSergey in https://github.com/spatie/laravel-littlegatekeeper/issues/18 the following commit https://github.com/spatie/laravel-littlegatekeeper/commit/7e7a129e71aa049f69f55716e264b2cf7b23b41e broke this package from working for at least non octane installs. This is also described here: https://github.com/spatie/laravel-littlegatekeeper/discussions/22. This PR uses bind instead of instance to resolve the error mentioned. 

I used bind as I wasn't sure how to set it up with a singleton while making sure to support Octane. (https://divinglaravel.com/laravel-octane-bootstrapping-the-application-and-handling-requests -> Passing the application instance to singletons). 

If I understand it correctly, singleton is in the end a proxy to bind with the shared boolean set to true (third parameter) https://laracasts.com/discuss/channels/general-discussion/bind-vs-singleton-when-and-what-to-choose. So I think it makes sense to use it like this.